### PR TITLE
Reduce clone instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,13 @@ Originally mGear was design and develope by Jeremie Passerin and Miquel Campos. 
 
 
 ### How to start your local git repository to build ([more instructions](https://github.com/mgear-dev/mgear_dist/blob/master/BUILD.md))
-```
-git clone git@github.com:mgear-dev/mgear_dist.git
-cd mgear_dist
-git submodule update --init
-git submodule foreach --recursive git checkout master
 
 ```
+git clone https://github.com/mgear-dev/mgear_dist.git --recursive
+```
+
 **Also to sync to the latest commit in every submodule**
+
 ```
 git submodule foreach git pull origin master
 ```


### PR DESCRIPTION
Also removes GitHub account requirement, by cloning from HTTPS as opposed to SSH